### PR TITLE
NoWait, and removed dependency on ConvertTo-TPLinkJSONCommand

### DIFF
--- a/Sources/Public/Send-TPLinkCommand.ps1
+++ b/Sources/Public/Send-TPLinkCommand.ps1
@@ -66,7 +66,9 @@ Function Send-TPLinkCommand {
 
         [Parameter(ParameterSetName='FriendlyCommand',Position=3)]
         [Parameter(ParameterSetName='JSONFormattedCommand',Position=3)]
-        [int]$Port = 9999
+        [int]$Port = 9999,
+		
+        [switch]$NoWait
     
     )
 
@@ -104,6 +106,9 @@ Function Send-TPLinkCommand {
     $Stream.write($EncodedCommand,0,$EncodedCommand.Length)
     $Stream.write($EncodedCommand,0,$EncodedCommand.Length)
 
+    #If NoWait, exit immediately and don't wait for response
+    if ($NoWait) { return $true }
+	
     #Wait for data to become available
     While ($TCPClient.Available -eq 0) {
             

--- a/Sources/Public/Send-TPLinkCommand.ps1
+++ b/Sources/Public/Send-TPLinkCommand.ps1
@@ -72,6 +72,14 @@ Function Send-TPLinkCommand {
     
     )
 
+    $JSONCommands = @{
+        SystemInfo = '{"system":{"get_sysinfo":null}}'
+        Reboot = '{"system":{"reboot":{"delay":1}}}'
+        Reset = '{"system":{"reset":{"delay":1}}}'
+        TurnOn = '{"system":{"set_relay_state":{"state":1}}}'
+        TurnOff = '{"system":{"set_relay_state":{"state":0}}}'
+    }
+
     #Create an instance of the .Net TCP Client class
     $TCPClient = New-Object -TypeName System.Net.Sockets.TCPClient
 
@@ -86,7 +94,7 @@ Function Send-TPLinkCommand {
         'FriendlyCommand' {
 
             #Convert the friendly command to the corresponding JSON command
-            $JSON = ConvertTo-TPLinkJSONCommand -InputObject $Command
+            $JSON = $JSONCommands.$Command
 
             #Convert the JSON command to TPLink byte format
             $EncodedCommand = ConvertTo-TPLinkDataFormat -Body $JSON


### PR DESCRIPTION
First off, solid work on figuring this out. Thank you.

Two changes here: the first is just the addition of $NoWait, which will let the script bomb out immediately after firing off the commands without waiting for a response for quicker simple on/off execution.

The second is just a change I made while testing the above, removing the need for the internal dependency on ConvertTo-TPLinkJSONCommand and instead using a hashtable defined in the cmdlet. I can split this one off if you'd prefer to leave it out.